### PR TITLE
skbprio_v2 comments addressed.

### DIFF
--- a/Documentation/networking/sch_skbprio.txt
+++ b/Documentation/networking/sch_skbprio.txt
@@ -1,0 +1,24 @@
+SKB Priority Queue
+==================
+ 
+This qdisc schedules a packet according to skb->priority, where a higher
+value places the packet closer to the exit of the queue. When the queue is
+full, the lowest priority packet in the queue is dropped to make room for
+the packet to be added if it has higher priority. If the packet to be added
+has lower priority than all packets in the queue, it is dropped.
+ 
+Without the SKB priority queue, queue length limits must be imposed
+for individual queues, and there is no easy way to enforce a global queue
+length limit across all priorities. With the SKBprio queue, a global
+queue length limit can be enforced while not restricting the queue lengths
+of individual priorities.
+ 
+This is especially useful for a denial-of-service defense system like
+Gatekeeper, which prioritizes packets in flows that demonstrate expected
+behavior of legitimate users. The queue is flexible to allow any number
+of packets of any priority up to the global limit of the scheduler
+without risking resource overconsumption by a flood of low priority packets.
+  
+The Gatekeeper codebase is found here:
+
+		https://github.com/AltraMayor/gatekeeper

--- a/include/uapi/linux/pkt_sched.h
+++ b/include/uapi/linux/pkt_sched.h
@@ -136,7 +136,7 @@ struct tc_fifo_qopt {
 #define SKBPRIO_MAX_PRIORITY 64
 
 struct tc_skbprio_qopt {
-	__u32	limit; 	    	/* Queue length in packets. */
+	__u32	limit;		/* Queue length in packets. */
 };
 
 /* PRIO section */


### PR DESCRIPTION
Hi guys, here is the code with some of the comments of the v2 patch addressed. Suggestions I haven't addressed:

(1) For Cong's suggestion of making the `struct tc_skbprio_opt` NLA_U32 wouldn't make much of an impact, we would have to be adding more code such `struct nla_policy` making it bloated, and its not how the other qdiscs use it.   

(2) Haven't addressed removing the comments in the beginning of the code which Alex suggested removing. Also didn't address changing the dropping at the tail rather than dropping at the head, as I don't think its what we intended for in functionality to begin with. 

Let me know if you'd like me to make any changes to these or to the code, and I'll do so. Hope it is good, thanks.